### PR TITLE
fix: Manage displayed nodes per buffer

### DIFF
--- a/autoload/viler.vim
+++ b/autoload/viler.vim
@@ -36,11 +36,11 @@ function! viler#open(...) abort
   setlocal shiftwidth=2
   setlocal softtabstop=2
   setlocal expandtab
+  setlocal bufhidden=hide
 
   if g:_viler_is_debug
     setlocal conceallevel=0
   else
-    setlocal bufhidden=hide
     setlocal nobuflisted
   endif
 

--- a/autoload/viler/Filer.vim
+++ b/autoload/viler/Filer.vim
@@ -69,7 +69,6 @@ function! s:Filer._assert_valid_commit_id(commit_id) abort
 endfunction
 
 function! s:Filer.display(dir, opts) abort
-  call self._nodes.clear_displayed_nodes()
   let dir_node = self._nodes.get_or_make_node_from_path(a:dir)
   let rows = self._list_children(a:dir, 0, a:opts)
   call self._buf.display_rows(self._commit_id, dir_node, rows)
@@ -153,7 +152,6 @@ function! s:Filer._list_children(dir, depth, opts) abort
     call add(rows, row)
 
     let row.node = self._nodes.get_or_make_node_from_path(viler#Path#join(a:dir, name))
-    call self._nodes.node_displayed(row.node.id, 1)
     if (get(a:opts, 'refresh_nodes', 0))
       call row.node.refresh()
     endif
@@ -269,7 +267,6 @@ function! s:Filer._close_tree(dir_node, dir_row) abort
     if row.depth <=# a:dir_row.depth
       break
     endif
-    call self._nodes.node_displayed(row.node_id, 0)
   endwhile
   if a:dir_row.lnum + 1 < l
     call self._buf.delete_lines(a:dir_row.lnum + 1, l - 1)
@@ -291,7 +288,6 @@ function! s:Filer.undo() abort
     return
   endif
 
-  call self._nodes.clear_displayed_nodes()
   call self._restore_nodes_on_buf(prev_dir)
 
   call self._buf.save()
@@ -306,7 +302,6 @@ function! s:Filer.redo() abort
   let prev_dir = self._buf.current_dir()
   let modified = self._buf.redo()
 
-  call self._nodes.clear_displayed_nodes()
   call self._restore_nodes_on_buf(prev_dir)
 
   if !modified
@@ -344,7 +339,6 @@ function! s:Filer._restore_nodes_on_buf(prev_dir) abort
 
     let file_path = viler#Path#join(dir_path, row.name)
     call self._get_or_make_node(row.node_id, row.commit_id, file_path)
-    call self._nodes.node_displayed(row.node_id, 1)
     let prev_depth = row.depth
     let prev_name = row.name
 

--- a/autoload/viler/Filetree.vim
+++ b/autoload/viler/Filetree.vim
@@ -19,7 +19,10 @@ endfunction
 
 function! s:Filetree.has_node_for(path) abort
   let node = self._node_store.try_get_node_from_path(a:path)
-  return type(node) isnot# v:t_number
+  if type(node) is# v:t_number
+    return 0
+  endif
+  return self._buf.should_be_displayed(node.id)
 endfunction
 
 function! s:Filetree.iter() abort

--- a/autoload/viler/Filetree.vim
+++ b/autoload/viler/Filetree.vim
@@ -19,7 +19,7 @@ endfunction
 
 function! s:Filetree.has_node_for(path) abort
   let node = self._node_store.try_get_node_from_path(a:path)
-  return type(node) isnot# v:t_number && self._node_store.should_be_displayed(node.id)
+  return type(node) isnot# v:t_number
 endfunction
 
 function! s:Filetree.iter() abort

--- a/autoload/viler/NodeStore.vim
+++ b/autoload/viler/NodeStore.vim
@@ -8,7 +8,6 @@ function! viler#NodeStore#new() abort
   let store._id = 0
   let store._nodes = {}
   let store._path2node = {}
-  let store._displayed_nodes = {}
   return store
 endfunction
 
@@ -47,20 +46,4 @@ function! s:NodeStore.get_or_make_node_from_path(abs_path) abort
     return self._path2node[a:abs_path] 
   endif
   return self.make_node(a:abs_path)
-endfunction
-
-function! s:NodeStore.clear_displayed_nodes() abort
-  let self._displayed_nodes = {}
-endfunction
-
-function! s:NodeStore.node_displayed(node_id, yes) abort
-  if a:yes
-    let self._displayed_nodes[a:node_id] = 1
-  elseif has_key(self._displayed_nodes, a:node_id)
-    call remove(self._displayed_nodes, a:node_id)
-  endif
-endfunction
-
-function! s:NodeStore.should_be_displayed(node_id) abort
-  return has_key(self._displayed_nodes, a:node_id)
 endfunction

--- a/autoload/viler/testutil/e2e.vim
+++ b/autoload/viler/testutil/e2e.vim
@@ -14,7 +14,7 @@ function! viler#testutil#e2e#setup(suite) abort
   endfunction
 
   " Manage buffers to clean up after each test.
-  call g:t.use_buffers(s:hooks, { 'auto_add_current_buf': 1 })
+  let bufs = g:t.use_buffers(s:hooks, { 'auto_add_current_buf': 1 })
 
   " Create a working directory.
   let work_dir = g:t.use_work_dir(s:hooks)
@@ -23,6 +23,7 @@ function! viler#testutil#e2e#setup(suite) abort
 
   let t = copy(s:E2eTestUtil)
   let t.work_dir = work_dir
+  let t.bufs = bufs
   return t
 endfunction
 

--- a/test/e2e/copy_one_file_over_multi_filers_test.vim
+++ b/test/e2e/copy_one_file_over_multi_filers_test.vim
@@ -1,0 +1,56 @@
+let s:suite = themis#suite('E2E')
+let s:assert = themis#helper('assert')
+let s:t = viler#testutil#e2e#setup(s:suite)
+
+function! s:suite.copy_one_file_over_multi_filers() abort
+  call s:t.work_dir.make_files([
+    \   'd1/',
+    \   '  a content:aaa',
+    \   'd2/',
+    \   '  b content:bbb',
+    \ ])
+
+  " Open a filer1.
+  let work_dir1_path = viler#Path#join(s:t.work_dir.path, 'd1') . '/'
+  call viler#open(work_dir1_path)
+  let buf1 = bufnr('%')
+  call s:assert.equals(s:t.displayed_lines(), [work_dir1_path, 'a'], 'initial lines (buf1)')
+
+  " Open a filer2.
+  let work_dir2_path = viler#Path#join(s:t.work_dir.path, 'd2') . '/'
+  call viler#open(work_dir2_path)
+  let buf2 = bufnr('%')
+  call s:t.bufs.add(buf2)
+  call s:assert.equals(s:t.displayed_lines(), [work_dir2_path, 'b'], 'initial lines (buf2)')
+
+  " Yank the line b.
+  execute '2yank x'
+
+  " Paste the line b at bottom of buffer1.
+  execute 'buffer' buf1
+  call cursor(2, 1)
+  normal! "xp
+  call s:assert.equals(s:t.displayed_lines(), [work_dir1_path, 'a', 'b'], 'lines after paste (buf1)')
+
+  call s:t.write_buffer()
+
+
+  " Check lines on filer1.
+  call s:assert.equals(s:t.displayed_lines(), [work_dir1_path, 'a', 'b'], 'lines after write (buf1)')
+
+  " Check lines on filer2.
+  execute 'buffer' buf2
+  call s:assert.equals(s:t.displayed_lines(), [work_dir2_path, 'b'], 'lines after write (buf2)')
+
+  " Check actual files.
+  let ffs = viler#testutil#FlistFs#create()
+  let got = ffs.files_to_flist(s:t.work_dir.path)
+  let want = [
+    \   'd1/',
+    \   '  a content:aaa',
+    \   '  b content:bbb',
+    \   'd2/',
+    \   '  b content:bbb',
+    \ ]
+  call s:assert.equals(got.lines(), want, 'actual files after write')
+endfunction

--- a/test/e2e/regression/can_delete_with_multi_filers_test.vim
+++ b/test/e2e/regression/can_delete_with_multi_filers_test.vim
@@ -1,0 +1,46 @@
+let s:suite = themis#suite('E2E')
+let s:assert = themis#helper('assert')
+let s:t = viler#testutil#e2e#setup(s:suite)
+
+function! s:suite.regression__can_delete_with_multi_filers() abort
+  call s:t.work_dir.make_files([
+    \   'd1/',
+    \   '  a content:aaa',
+    \   'd2/',
+    \   '  b content:bbb',
+    \ ])
+
+  " Open a filer1.
+  let work_dir1_path = viler#Path#join(s:t.work_dir.path, 'd1') . '/'
+  call viler#open(work_dir1_path)
+  let buf1 = bufnr('%')
+  call s:assert.equals(s:t.displayed_lines(), [work_dir1_path, 'a'], 'initial lines (buf1)')
+
+  " Open a filer2.
+  let work_dir2_path = viler#Path#join(s:t.work_dir.path, 'd2') . '/'
+  call viler#open(work_dir2_path)
+  let buf2 = bufnr('%')
+  call s:t.bufs.add(buf2)
+  call s:assert.equals(s:t.displayed_lines(), [work_dir2_path, 'b'], 'initial lines (buf2)')
+
+  " Back to filer1.
+  execute 'buffer' buf1
+  " Delete line a.
+  execute '2delete'
+  call s:assert.equals(s:t.displayed_lines(), [work_dir1_path], 'lines after delete (buf1)')
+
+  call s:t.write_buffer()
+
+  " Check lines on filer1.
+  call s:assert.equals(s:t.displayed_lines(), [work_dir1_path], 'lines after write (buf1)')
+
+  " Check actual files.
+  let ffs = viler#testutil#FlistFs#create()
+  let got = ffs.files_to_flist(s:t.work_dir.path)
+  let want = [
+    \   'd1/',
+    \   'd2/',
+    \   '  b content:bbb',
+    \ ]
+  call s:assert.equals(got.lines(), want, 'actual files after write')
+endfunction


### PR DESCRIPTION
😱  (details: c816178)

The implementation of 412c382 was a horrible bug...
It manages the `displayed_nodes` state (a set of node ids currently displayed in a buffer) globally, in a single place. But Viler supports multiple filers and each filer can display different nodes, so the state must be managed per buffer.